### PR TITLE
Dev UI: always produce JsonRPCProvidersBuildItem

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/mdns/deployment/devui/MdnsDevUIProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/mdns/deployment/devui/MdnsDevUIProcessor.java
@@ -40,7 +40,7 @@ public class MdnsDevUIProcessor {
         cardPageBuildItemBuildProducer.produce(card);
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(MdnsJsonRPCService.class);
     }


### PR DESCRIPTION
This is due to an upcoming change in Execution Model Validation [1] where we need the `JsonRPCProvidersBuildItem` produced always, not only in dev mode. JSON RPC providers can use execution model affecting annotations, so we need to know about them, otherwise a non-dev build would fail with an incorrect validation error.

[1] https://github.com/quarkusio/quarkus/pull/46965